### PR TITLE
Fix session field value for first render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "nebenan-redux-tools",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "5.11.0",
+      "version": "5.11.1",
       "license": "SEE LICENSE IN LICENSE FILE",
       "dependencies": {
         "js-cookie": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-redux-tools",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-redux-tools/issues",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/src/session/hooks.jsx
+++ b/src/session/hooks.jsx
@@ -10,8 +10,8 @@ const getSession = ({ session }) => session;
 export const useSession = () => useShallowEqualSelector(getSession);
 
 export const useSessionField = (fieldPath, defaultValue = null) => {
-  const [value, setValue] = useState(defaultValue);
   const session = useSession();
+  const [value, setValue] = useState(getField(session, fieldPath) ?? defaultValue);
 
   useEffect(() => {
     setValue(getField(session, fieldPath));


### PR DESCRIPTION
`useSessionField` only returned `defaultValue` on first render despite the value being in the session