### PR TITLE
Add util to generate state updates for multiple lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nebenan-redux-tools",
-  "version": "6.2.0-beta.3",
+  "version": "6.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nebenan-redux-tools",
-      "version": "6.2.0-beta.3",
+      "version": "6.2.0",
       "license": "SEE LICENSE IN LICENSE FILE",
       "dependencies": {
         "axios": "^0.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nebenan-redux-tools",
-  "version": "6.1.0",
+  "version": "6.2.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nebenan-redux-tools",
-      "version": "6.1.0",
+      "version": "6.2.0-beta.3",
       "license": "SEE LICENSE IN LICENSE FILE",
       "dependencies": {
         "axios": "^0.21.0",
@@ -2187,14 +2187,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001307",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
-      "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -7099,9 +7105,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001307",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
-      "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true
     },
     "chai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "nebenan-redux-tools",
       "version": "6.0.0",
       "license": "SEE LICENSE IN LICENSE FILE",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-redux-tools",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-redux-tools/issues",
-  "version": "6.2.0-beta.3",
+  "version": "6.2.0",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://nebenan.de/",
   "repository": "good-hood-gmbh/nebenan-redux-tools",
   "bugs": "https://github.com/good-hood-gmbh/nebenan-redux-tools/issues",
-  "version": "6.1.0",
+  "version": "6.2.0-beta.3",
   "files": [
     "lib/*.js",
     "lib/*/*.js"

--- a/src/network/pagination.jsx
+++ b/src/network/pagination.jsx
@@ -1,4 +1,5 @@
 import defaults from 'lodash/defaults';
+import { mapValues } from 'lodash';
 import { has } from '../utils';
 import { resolved, rejected } from './types';
 
@@ -45,6 +46,19 @@ export const paginationGenerator = (type) => (
     return update;
   }
 );
+
+export const paginationGenerators = (typesByStateKey) => {
+  const updaters = mapValues(typesByStateKey, (type) => paginationGenerator(type));
+
+  return (state = {}, action) => (
+    Object.keys(updaters).reduce((updates, stateKey) => {
+      const update = updaters[stateKey](state[stateKey], action);
+      if (!update) return updates;
+
+      return { ...updates, [stateKey]: update };
+    }, {})
+  );
+};
 
 export const assignPaginationDefaults = (state) => ({ ...state, ...getPaginationDefaults() });
 

--- a/src/network/pagination.jsx
+++ b/src/network/pagination.jsx
@@ -1,5 +1,5 @@
 import defaults from 'lodash/defaults';
-import { mapValues } from 'lodash';
+import mapValues from 'lodash/mapValues';
 import { has } from '../utils';
 import { resolved, rejected } from './types';
 
@@ -17,6 +17,10 @@ export const getPaginationDefaults = () => ({
   collection: [],
 });
 
+/**
+ * Provides updates for a given type and state to handle list loading, successful fetch and
+ * failed fetch.
+ */
 export const paginationGenerator = (type) => (
   (state = {}, action) => {
     let update = null;
@@ -47,6 +51,9 @@ export const paginationGenerator = (type) => (
   }
 );
 
+/**
+ * Same thing as `paginationGenerator` but supports multiple lists.
+ */
 export const paginationGenerators = (typesByStateKey) => {
   const updaters = mapValues(typesByStateKey, (type) => paginationGenerator(type));
 

--- a/test/network/pagination.js
+++ b/test/network/pagination.js
@@ -11,6 +11,7 @@ const {
   PAGINATION_DEFAULTS,
   assignPaginationDefaults,
   paginationGenerator,
+  paginationGenerators,
   buildPaginationQuery,
 } = require('../../lib/network/pagination');
 
@@ -91,6 +92,71 @@ describe('network/pagination', () => {
       assert.equal(state.total, null, 'total kept previous value');
       assert.isFalse(state.isFetching, 'Fetching set');
       assert.isTrue(state.isFailed, 'isFailed set');
+    });
+  });
+
+  describe('paginationGenerators', () => {
+    it('collects updates for multiple generators in one update', () => {
+      const actions = {
+        FETCH_MAIN_LIST: 'FETCH_LIST',
+        FETCH_CUSTOM_LIST: 'FETCH_CUSTOM_LIST',
+      };
+
+      const pagination = paginationGenerators({
+        mainList: actions.FETCH_MAIN_LIST,
+        customList: actions.FETCH_CUSTOM_LIST,
+      });
+
+      assert.deepEqual(
+        pagination(
+          {
+            mainList: {},
+            customList: {},
+          },
+          { type: 'UNKOWN_ACTION', payload: { } },
+        ),
+        {
+          mainList: {
+            collection: [],
+            currentPage: 0,
+            lastFetched: 0,
+            total: null,
+          },
+
+          customList: {
+            collection: [],
+            currentPage: 0,
+            lastFetched: 0,
+            total: null,
+          },
+        },
+        'returns initialization updates for all lists',
+      );
+
+      assert.deepEqual(
+        pagination(
+          {
+            mainList: {
+              collection: [],
+              currentPage: 0,
+              lastFetched: 0,
+              total: null,
+            },
+
+            customList: {
+              collection: [],
+              currentPage: 0,
+              lastFetched: 0,
+              total: null,
+            },
+          },
+          { type: rejected(actions.FETCH_MAIN_LIST), payload: { total_count: 123 } },
+        ),
+        {
+          mainList: { isFetching: false, currentPage: 0, isFailed: true },
+        },
+        'returns update for mainList',
+      );
     });
   });
 


### PR DESCRIPTION
Many times we keep multiple lists in the same reducer state and want to enable pagination on all of them. This change should get complexity out of the apps and move it here next to the other pagination logic.

PR inspired by @zeitwidrig 's [comment](https://github.com/good-hood-gmbh/nebenan-frontend/pull/1780/files/e67d29e256a1682f4cdae7e17ea92c415b05e34c#r992284317)