### PR TITLE
Remove unnecessary yalc script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lint": "eslint --ext .es,.js ./",
     "lint:tofile": "eslint --ext .es,.js --no-color -o ./eslint-report.log ./",
     "test": "npm run compile && TZ='GMT' mocha \"test/**/*.js\"",
-    "test:tofile": "npm run compile && TZ='GMT' mocha --no-colors -R spec \"test/**/*.js\" 2>&1 | tee test-report.log",
-    "yalc": "npm run build && yalc push"
+    "test:tofile": "npm run compile && TZ='GMT' mocha --no-colors -R spec \"test/**/*.js\" 2>&1 | tee test-report.log"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
Pretty sure we don't need any additional scripts for yalc since it runs `prepublishOnly` on `yalc publish` (same as `npm publish`)